### PR TITLE
Dev/path prefix for ga

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ const tracker = new Tracker({
   userId: 'ridi',
   gaOptions: {
     trackingId: 'UA-XXXXXXXX-X',
+    pathPrefix: '/PAPERSHOP',
     fields: {
       contentGroup5: 'PAPERSHOP'
     }
@@ -52,6 +53,7 @@ tracker.sendPageView(location.href);
 | `deviceType`              | true     | `DeviceType`    | Type of connected user's device. Please refer `DeviceType` type |
 | `gaOptions`               | true     | `GAOptions`     | Options related with Google Analytics tracking module        |
 | `gaOptions.trackingId`    | true     | `string`        | GA Tracking ID like `UA-000000-01`.                          |
+| `gaOptions.pathPrefix`    | flase    | `string`        | Pathname prefix for manual content grouping.                          |
 | `gaOptions.fields`        | false    | `string`        | [GA configurable create only fields.](https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference) |
 | `beaconOptions`           | false    | `BeaconOptions` | Options related with Beacon tracking module                  |
 | `beaconOptions.beaconSrc` | false    | `string`        | Source of the image to be used as a beacon                   |

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,18 +25,9 @@
       "dev": true
     },
     "@types/url-parse": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.1.0.tgz",
-      "integrity": "sha512-R3R19GWiA8YSB8UCs/nDqBZhgvdCae/URs5vE/6oldQ9NGjuXueicXNHmux+BJV67I8y+XBP4kBkCJ6NWGz0Gw==",
-      "dev": true,
-      "requires": {
-        "@types/url-search-params": "*"
-      }
-    },
-    "@types/url-search-params": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@types/url-search-params/-/url-search-params-0.10.1.tgz",
-      "integrity": "sha512-rDNpG5l+DOrfl1yHbuFQT8//0+qAapjIxZWunvNPI5neZ5ZkZrZHCqsg3GxmJo8SfzzBdbmVqYRx7/UFJbPIsg==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@types/url-parse/-/url-parse-1.4.1.tgz",
+      "integrity": "sha512-3McaEYdd8DHiXqOTx36PaZdbc8l8drr9iJQYCaKnEsgd/n5JIEgIVCaSVSZqtDik4Pydax1Zo+JB99r82bBYDA==",
       "dev": true
     },
     "@webassemblyjs/ast": {
@@ -4233,9 +4224,9 @@
       }
     },
     "url-parse": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.1.tgz",
-      "integrity": "sha512-x95Td74QcvICAA0+qERaVkRpTGKyBHHYdwL2LXZm5t/gBtCB9KQSO/0zQgSTYEV1p0WcvSg79TLNPSvd5IDJMQ==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.4.3.tgz",
+      "integrity": "sha512-rh+KuAW36YKo0vClhQzLLveoj8FwPJNu65xLb7Mrt+eZht0IPT0IXgSv8gcMegZ6NvjJUALf6Mf25POlMwD1Fw==",
       "requires": {
         "querystringify": "^2.0.0",
         "requires-port": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -23,12 +23,12 @@
     "@types/google.analytics": "0.0.39",
     "js-cookie": "^2.2.0",
     "performance-now": "^2.1.0",
-    "url-parse": "^1.4.1"
+    "url-parse": "^1.4.3"
   },
   "devDependencies": {
     "@ridi/tslint-config": "^0.1.0",
     "@types/js-cookie": "^2.1.0",
-    "@types/url-parse": "^1.1.0",
+    "@types/url-parse": "^1.4.1",
     "pre-commit": "^1.2.2",
     "prettier": "1.13.4",
     "ts-loader": "^4.4.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,7 @@ export class Tracker {
 
   private getPageMeta(href: string, referrer: string = ''): PageMeta {
     const url = new URL(href, {}, true);
-    const path = url.pathname + new URL(href, {}, false).query;
+    const path = url.pathname;
     return {
       page: url.pathname.split("/")[1] || "index",
       device: this.options.deviceType,

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ export class Tracker {
 
   private trackers: BaseTracker[] = [];
 
-  private getPageMeta(href: string, referrer?: string): PageMeta {
+  private getPageMeta(href: string, referrer: string = ''): PageMeta {
     const url = new URL(href, {}, true);
     const path = url.pathname + new URL(href, {}, false).query;
     return {
@@ -43,7 +43,7 @@ export class Tracker {
       query_params: url.query,
       path,
       href,
-      referrer: referrer || document.referrer
+      referrer,
     };
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import parse from "url-parse";
+import URL from "url-parse";
 
 import { BeaconOptions, BeaconTracker, GAOptions, GATracker } from "./trackers";
 import { BaseTracker, PageMeta } from "./trackers/base";
@@ -35,8 +35,8 @@ export class Tracker {
   private trackers: BaseTracker[] = [];
 
   private getPageMeta(href: string, referrer?: string): PageMeta {
-    const url = parse(href, true);
-    const path = url.pathname + parse(href, false).query;
+    const url = new URL(href, {}, true);
+    const path = url.pathname + new URL(href, {}, false).query;
     return {
       page: url.pathname.split("/")[1] || "index",
       device: this.options.deviceType,

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -1,3 +1,5 @@
+import URL from "url-parse";
+
 import { RUID } from "../uid";
 import { UIDFactory } from "../uid/factory";
 import { BaseTracker, PageMeta } from "./base";
@@ -34,12 +36,14 @@ export class BeaconTracker extends BaseTracker {
 
   private sendEvent(eventName: BeaconEventName, pageMeta: PageMeta) {
     const ruid = new UIDFactory(RUID).getOrCreate();
+    const search = `?${URL.qs.stringify(pageMeta.query_params)}`;
 
     const log: BeaconLog = {
       event: eventName,
       user_id: this.mainOptions.userId,
       ruid: ruid.value,
-      ...pageMeta
+      ...pageMeta,
+      path: `${pageMeta.path}${search}`
     };
 
     fetch(this.makeBeaconURL(log));

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -14,7 +14,11 @@ export class GATracker extends BaseTracker {
 
   private refinePath(originalPath: string): string {
     const refiners: Array<(path: string) => string> = [
-      path => (this.options.pathPrefix ? this.options.pathPrefix + path : path)
+      path => (this.options.pathPrefix ? this.options.pathPrefix + path : path),
+
+      // Pathname in some browsers doesn't start with slash character (/)
+      // Ref: https://app.asana.com/0/inbox/463186034180509/765912307342230/766156873493449
+      path => (path.startsWith("/") ? path : `/${path}`)
     ];
 
     return refiners.reduce((value, refiner) => {

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -3,12 +3,23 @@ import { BaseTracker, PageMeta } from "./base";
 
 export interface GAOptions {
   trackingId: string;
+  pathPrefix?: string;
   fields?: UniversalAnalytics.FieldsObject;
 }
 
 export class GATracker extends BaseTracker {
   constructor(private options: GAOptions) {
     super();
+  }
+
+  private refinePath(originalPath: string): string {
+    const refiners: Array<(path: string) => string> = [
+      path => (this.options.pathPrefix ? this.options.pathPrefix + path : path)
+    ];
+
+    return refiners.reduce((value, refiner) => {
+      return refiner(value);
+    }, originalPath);
   }
 
   public initialize(): void {
@@ -25,7 +36,9 @@ export class GATracker extends BaseTracker {
   }
 
   public sendPageView(pageMeta: PageMeta): void {
-    ga("send", "pageview", pageMeta.path, {
+    const refinedPath = this.refinePath(pageMeta.path);
+
+    ga("send", "pageview", refinedPath, {
       dimension1: this.mainOptions.deviceType
     });
   }


### PR DESCRIPTION
- `MainTrackerOptions.gaOptions.pathPrefix` 추가
- `pathname` 에 첫번째 slash (`/`) 가 빠져서 들어오는 경우 대응
- `sendPageView` 메소드 에서, `referrer` 인자가 없는 경우 `document.referrer` 를 참조하던 코드 제거. 
  - `referrer` 인자가 없는 경우 빈 문자열로 `referrer` 값을 대체하게 됩니다.