### PR TITLE
Release 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",


### PR DESCRIPTION
- `MainTrackerOptions.gaOptions.pathPrefix` 추가 #4
- `pathname` 에 첫번째 slash (`/`) 가 빠져서 들어오는 경우 대응 #4
- `sendPageView` 메소드 에서, `referrer` 인자가 없는 경우 `document.referrer` 를 참조하던 코드 제거.  #4
  - `referrer` 인자가 없는 경우 빈 문자열로 `referrer` 값을 대체하게 됩니다. 