### PR TITLE
Call ga("set", "page", refinedPath") before send pageview event

### DIFF
--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -42,7 +42,9 @@ export class GATracker extends BaseTracker {
   public sendPageView(pageMeta: PageMeta): void {
     const refinedPath = this.refinePath(pageMeta.path);
 
-    ga("send", "pageview", refinedPath, {
+    ga("set", "page", refinedPath);
+
+    ga("send", "pageview", {
       dimension1: this.mainOptions.deviceType
     });
   }


### PR DESCRIPTION
according to [Google Analytics Document](https://developers.google.com/analytics/devguides/collection/analyticsjs/single-page-applications#tracking_virtual_pageviews)