### PR TITLE
Fix BeaconTracker isInitialized check

### DIFF
--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -63,7 +63,7 @@ export class BeaconTracker extends BaseTracker {
   }
 
   public isInitialized(): boolean {
-    return true;
+    return !!this.ruid;
   }
 
   public sendPageView(pageMeta: PageMeta): void {


### PR DESCRIPTION
- BeaconTracker isInitialized 에서 늘 true 를 반환하는 부분을 ruid 존재여부로 변경했습니다.

https://github.com/ridi/event-tracker/issues/21