### PR TITLE
Fix/missing query string

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,15 +1,10 @@
 import {DeviceType, Tracker} from "../index";
-import {
-  BeaconTracker,
-  GATracker,
-  PixelTracker,
-  TagManagerTracker
-} from "../trackers";
-
+import {BeaconTracker, GATracker, PixelTracker, TagManagerTracker} from "../trackers";
 
 beforeAll(() => {
   document.body.innerHTML = "<script />";
 });
+
 
 const createDummyTracker = (additionalOptions: object = {}) => {
   return new Tracker({
@@ -29,6 +24,29 @@ const createDummyTracker = (additionalOptions: object = {}) => {
     ...additionalOptions
   });
 };
+
+it("GATracker should send pageview event", () => {
+
+  [BeaconTracker, PixelTracker, TagManagerTracker].map(
+    tracker => {
+      const mock = jest.fn();
+      tracker.prototype.sendPageView = mock;
+      return mock;
+    }
+  );
+
+  const t = createDummyTracker();
+
+  const href = "https://localhost/home?q=localhost&adult_exclude=true";
+  const referrer = "https://google.com/search?q=localhost";
+
+  t.initialize();
+  ga = jest.fn() as unknown as UniversalAnalytics.ga
+  t.sendPageView(href, referrer);
+
+  expect(ga).toHaveBeenCalledWith("set", "page", "/home?q=localhost&adult_exclude=true")
+
+});
 
 it("sends PageView event with all tracking providers", () => {
   const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
@@ -50,6 +68,9 @@ it("sends PageView event with all tracking providers", () => {
     expect(mock).toBeCalledTimes(1);
   });
 });
+
+
+
 
 
 it("throws if initialize have not been called before sending any events ", () => {

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -30,7 +30,7 @@ const createDummyTracker = (additionalOptions: object = {}) => {
 };
 
 it("sends PageView event with all tracking providers", () => {
-  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+  const mocks = [BeaconTracker,GATracker, PixelTracker, TagManagerTracker].map(
     tracker => {
       const mock = jest.fn();
       tracker.prototype.sendPageView = mock;
@@ -51,7 +51,8 @@ it("sends PageView event with all tracking providers", () => {
 });
 
 it("path should contains querystring of href", () => {
-  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+
+  const mocks = [BeaconTracker, PixelTracker, TagManagerTracker].map(
     tracker => {
       const mock = jest.fn();
       tracker.prototype.sendPageView = mock;
@@ -65,18 +66,11 @@ it("path should contains querystring of href", () => {
   const referrer = "https://google.com/search?q=localhost";
 
   t.initialize();
+  ga = jest.fn() as unknown as UniversalAnalytics.ga
   t.sendPageView(href, referrer);
+  expect(ga).toHaveBeenCalledWith("set", "page", "/home?q=localhost&adult_exclude=true")
 
-  mocks.forEach(mock => {
-    expect(mock).nthCalledWith(1, {
-      page: 'home',
-      device: 'mobile',
-      query_params: {adult_exclude: 'true', q: "localhost"},
-      path: '/home?q=localhost&adult_exclude=true',
-      href: 'https://localhost/home?q=localhost&adult_exclude=true',
-      referrer: 'https://google.com/search?q=localhost'
-    })
-  });
+
 });
 
 

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -31,7 +31,7 @@ const createDummyTracker = (additionalOptions: object = {}) => {
 };
 
 it("sends PageView event with all tracking providers", () => {
-  const mocks = [BeaconTracker,GATracker, PixelTracker, TagManagerTracker].map(
+  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
     tracker => {
       const mock = jest.fn();
       tracker.prototype.sendPageView = mock;

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -6,6 +6,7 @@ import {
   TagManagerTracker
 } from "../trackers";
 
+
 beforeAll(() => {
   document.body.innerHTML = "<script />";
 });
@@ -48,29 +49,6 @@ it("sends PageView event with all tracking providers", () => {
   mocks.forEach(mock => {
     expect(mock).toBeCalledTimes(1);
   });
-});
-
-it("path should contains querystring of href", () => {
-
-  const mocks = [BeaconTracker, PixelTracker, TagManagerTracker].map(
-    tracker => {
-      const mock = jest.fn();
-      tracker.prototype.sendPageView = mock;
-      return mock;
-    }
-  );
-
-  const t = createDummyTracker();
-
-  const href = "https://localhost/home?q=localhost&adult_exclude=true";
-  const referrer = "https://google.com/search?q=localhost";
-
-  t.initialize();
-  ga = jest.fn() as unknown as UniversalAnalytics.ga
-  t.sendPageView(href, referrer);
-  expect(ga).toHaveBeenCalledWith("set", "page", "/home?q=localhost&adult_exclude=true")
-
-
 });
 
 

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,4 +1,4 @@
-import { DeviceType, Tracker } from "../index";
+import {DeviceType, Tracker} from "../index";
 import {
   BeaconTracker,
   GATracker,
@@ -49,6 +49,36 @@ it("sends PageView event with all tracking providers", () => {
     expect(mock).toBeCalledTimes(1);
   });
 });
+
+it("path should contains querystring of href", () => {
+  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+    tracker => {
+      const mock = jest.fn();
+      tracker.prototype.sendPageView = mock;
+      return mock;
+    }
+  );
+
+  const t = createDummyTracker();
+
+  const href = "https://localhost/home?q=localhost&adult_exclude=true";
+  const referrer = "https://google.com/search?q=localhost";
+
+  t.initialize();
+  t.sendPageView(href, referrer);
+
+  mocks.forEach(mock => {
+    expect(mock).nthCalledWith(1, {
+      page: 'home',
+      device: 'mobile',
+      query_params: {adult_exclude: 'true', q: "localhost"},
+      path: '/home?q=localhost&adult_exclude=true',
+      href: 'https://localhost/home?q=localhost&adult_exclude=true',
+      referrer: 'https://google.com/search?q=localhost'
+    })
+  });
+});
+
 
 it("throws if initialize have not been called before sending any events ", () => {
   const t = createDummyTracker();

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -41,10 +41,10 @@ it("GATracker should send pageview event", () => {
   const referrer = "https://google.com/search?q=localhost";
 
   t.initialize();
-  ga = jest.fn() as unknown as UniversalAnalytics.ga
+  ga = jest.fn() as unknown as UniversalAnalytics.ga;
   t.sendPageView(href, referrer);
 
-  expect(ga).toHaveBeenCalledWith("set", "page", "/home?q=localhost&adult_exclude=true")
+  expect(ga).toHaveBeenCalledWith("set", "page", "/home?q=localhost&adult_exclude=true");
 
 });
 
@@ -68,9 +68,6 @@ it("sends PageView event with all tracking providers", () => {
     expect(mock).toBeCalledTimes(1);
   });
 });
-
-
-
 
 
 it("throws if initialize have not been called before sending any events ", () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,7 +64,10 @@ export class Tracker {
 
   private getPageMeta(href: string, referrer: string = ""): PageMeta {
     const url = new URL(href, {}, true);
-    const path = url.pathname;
+    const queryString = url.href.split("?")[1] || ""
+
+    const path = `${url.pathname}?${queryString}`;
+
     return {
       page: url.pathname.split("/")[1] || "index",
       device: this.options.deviceType,
@@ -125,6 +128,7 @@ export class Tracker {
     this.throwIfInitializeIsNotCalled();
 
     const pageMeta = this.getPageMeta(href, referrer);
+
     for (const tracker of this.trackers) {
       tracker.sendPageView(pageMeta);
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,9 +64,8 @@ export class Tracker {
 
   private getPageMeta(href: string, referrer: string = ""): PageMeta {
     const url = new URL(href, {}, true);
-    const queryString = url.href.split("?")[1] || ""
 
-    const path = `${url.pathname}?${queryString}`;
+    const path = url.pathname;
 
     return {
       page: url.pathname.split("/")[1] || "index",

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -16,13 +16,14 @@ export class GATracker extends BaseTracker {
     super();
   }
 
-  private refinePath(originalPath: string): string {
+  private refinePath(originalPath: string, href: string): string {
     const refiners: Array<(path: string) => string> = [
       path => (this.options.pathPrefix ? this.options.pathPrefix + path : path),
 
       // Pathname in some browsers doesn't start with slash character (/)
       // Ref: https://app.asana.com/0/inbox/463186034180509/765912307342230/766156873493449
-      path => (path.startsWith("/") ? path : `/${path}`)
+      path => (path.startsWith("/") ? path : `/${path}`),
+      path => `${path}?${href.split("?")[1] || ""}`
     ];
 
     return refiners.reduce((value, refiner) => {
@@ -44,7 +45,7 @@ export class GATracker extends BaseTracker {
   }
 
   public sendPageView(pageMeta: PageMeta): void {
-    const refinedPath = this.refinePath(pageMeta.path);
+    const refinedPath = this.refinePath(pageMeta.path, pageMeta.href);
 
     ga("set", "page", refinedPath);
 

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -1,5 +1,5 @@
-import { loadGA } from "../utils/externalServices";
-import { BaseTracker, PageMeta } from "./base";
+import {loadGA} from "../utils/externalServices";
+import {BaseTracker, PageMeta} from "./base";
 
 interface GAFields extends UniversalAnalytics.FieldsObject {
   allowAdFeatures?: boolean;

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -22,7 +22,7 @@ export class GATracker extends BaseTracker {
 
       // Pathname in some browsers doesn't start with slash character (/)
       // Ref: https://app.asana.com/0/inbox/463186034180509/765912307342230/766156873493449
-      path => (path.startsWith("/") ? path : `/${path}`),
+      path => (path.startsWith("/") ? path : `/${path}`)
     ];
 
     return refiners.reduce((value, refiner) => {
@@ -45,9 +45,9 @@ export class GATracker extends BaseTracker {
 
   public sendPageView(pageMeta: PageMeta): void {
     const refinedPath = this.refinePath(pageMeta.path);
-    const queryString = pageMeta.href.split("?")[1] || ""
+    const queryString = pageMeta.href.split("?")[1] || "";
 
-    const pageName = `${refinedPath}?${queryString}`
+    const pageName = `${refinedPath}?${queryString}`;
 
     ga("set", "page", pageName);
 

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -16,14 +16,13 @@ export class GATracker extends BaseTracker {
     super();
   }
 
-  private refinePath(originalPath: string, href: string): string {
+  private refinePath(originalPath: string): string {
     const refiners: Array<(path: string) => string> = [
       path => (this.options.pathPrefix ? this.options.pathPrefix + path : path),
 
       // Pathname in some browsers doesn't start with slash character (/)
       // Ref: https://app.asana.com/0/inbox/463186034180509/765912307342230/766156873493449
       path => (path.startsWith("/") ? path : `/${path}`),
-      path => `${path}?${href.split("?")[1] || ""}`
     ];
 
     return refiners.reduce((value, refiner) => {
@@ -45,9 +44,12 @@ export class GATracker extends BaseTracker {
   }
 
   public sendPageView(pageMeta: PageMeta): void {
-    const refinedPath = this.refinePath(pageMeta.path, pageMeta.href);
+    const refinedPath = this.refinePath(pageMeta.path);
+    const queryString = pageMeta.href.split("?")[1] || ""
 
-    ga("set", "page", refinedPath);
+    const pageName = `${refinedPath}?${queryString}`
+
+    ga("set", "page", pageName);
 
     ga("send", "pageview", {
       dimension1: this.mainOptions.deviceType


### PR DESCRIPTION
- 관련 아사나 테스크 : [event-tracker에서 path에 query param을 붙여주도록 변경](https://app.asana.com/0/inbox/1151769857741114)

- 변경 내용

    - `GATracker.path`에 queryString을 추가하도록 수정했습니다.

    - 머지 후 npm에 배포할 예정입니다.