### PR TITLE
Dev/service props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.8.5",
+  "version": "0.8.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.8.7",
+  "version": "0.8.8",
   "description": "",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -9,6 +9,10 @@ beforeAll(() => {
 const createDummyTracker = (additionalOptions: object = {}) => {
   return new Tracker({
     deviceType: DeviceType.Mobile,
+    serviceProps: {
+      "prop1": "value1",
+      "prop2": "value2"
+    },
     beaconOptions: {
       use: true
     },
@@ -24,6 +28,42 @@ const createDummyTracker = (additionalOptions: object = {}) => {
     ...additionalOptions
   });
 };
+
+// TODO: fix this test works.
+//  For now, we need to
+//    1) make BeaconTacker.sendBeacon as public method
+//    2) comment out "GATracker should send pageview event" Test
+//  temporarily to pass this test.
+// it("BeaconTracker sends PageView event with serviceProps", () => {
+//   const dummpyPageMeta = {
+//     "device": "mobile",
+//     "href": "https://localhost/home?q=localhost&adult_exclude=true",
+//     "page": "home",
+//     "path": "/home",
+//     "query_params": {"adult_exclude": "true", "q": "localhost"},
+//     "referrer": "https://google.com/search?q=localhost"
+//   };
+//
+//   [GATracker, PixelTracker, TagManagerTracker].map(
+//     tracker => {
+//       const mock = jest.fn();
+//       tracker.prototype.sendPageView = mock;
+//       return mock;
+//     }
+//   );
+//
+//   const t = createDummyTracker();
+//
+//   const href = "https://localhost/home?q=localhost&adult_exclude=true";
+//   const referrer = "https://google.com/search?q=localhost";
+//
+//   t.initialize();
+//   const sendBeaconMock = jest.fn();
+//   BeaconTracker.prototype.sendBeacon = sendBeaconMock;
+//   t.sendPageView(href, referrer);
+//
+//   expect(sendBeaconMock).toHaveBeenCalledWith("pageView", dummpyPageMeta, {"prop1": "value1", "prop2": "value2"});
+// });
 
 it("GATracker should send pageview event", () => {
 

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,8 +1,24 @@
 import {DeviceType, Tracker} from "../index";
 import {BeaconTracker, GATracker, PixelTracker, TagManagerTracker} from "../trackers";
+import {BaseTracker} from "../trackers/base";
+
+let originalFunctions: Array<typeof BaseTracker.prototype.sendPageView>
 
 beforeAll(() => {
   document.body.innerHTML = "<script />";
+  originalFunctions = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+    tracker => {
+      return tracker.prototype.sendPageView
+    }
+  )
+});
+
+afterEach(() => {
+    [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+      (tracker, index) => {
+        tracker.prototype.sendPageView = originalFunctions[index]
+      }
+    )
 });
 
 
@@ -29,41 +45,60 @@ const createDummyTracker = (additionalOptions: object = {}) => {
   });
 };
 
-// TODO: fix this test works.
-//  For now, we need to
-//    1) make BeaconTacker.sendBeacon as public method
-//    2) comment out "GATracker should send pageview event" Test
-//  temporarily to pass this test.
-// it("BeaconTracker sends PageView event with serviceProps", () => {
-//   const dummpyPageMeta = {
-//     "device": "mobile",
-//     "href": "https://localhost/home?q=localhost&adult_exclude=true",
-//     "page": "home",
-//     "path": "/home",
-//     "query_params": {"adult_exclude": "true", "q": "localhost"},
-//     "referrer": "https://google.com/search?q=localhost"
-//   };
-//
-//   [GATracker, PixelTracker, TagManagerTracker].map(
-//     tracker => {
-//       const mock = jest.fn();
-//       tracker.prototype.sendPageView = mock;
-//       return mock;
-//     }
-//   );
-//
-//   const t = createDummyTracker();
-//
-//   const href = "https://localhost/home?q=localhost&adult_exclude=true";
-//   const referrer = "https://google.com/search?q=localhost";
-//
-//   t.initialize();
-//   const sendBeaconMock = jest.fn();
-//   BeaconTracker.prototype.sendBeacon = sendBeaconMock;
-//   t.sendPageView(href, referrer);
-//
-//   expect(sendBeaconMock).toHaveBeenCalledWith("pageView", dummpyPageMeta, {"prop1": "value1", "prop2": "value2"});
-// });
+it("BeaconTracker sends PageView event with serviceProps", () => {
+  const dummpyPageMeta = {
+    "device": "mobile",
+    "href": "https://localhost/home?q=localhost&adult_exclude=true",
+    "page": "home",
+    "path": "/home",
+    "query_params": {"adult_exclude": "true", "q": "localhost"},
+    "referrer": "https://google.com/search?q=localhost"
+  };
+
+  [GATracker, PixelTracker, TagManagerTracker].map(
+    tracker => {
+      const mock = jest.fn();
+      tracker.prototype.sendPageView = mock;
+      return mock;
+    }
+  );
+
+  const t = createDummyTracker();
+
+  const href = "https://localhost/home?q=localhost&adult_exclude=true";
+  const referrer = "https://google.com/search?q=localhost";
+
+  t.initialize();
+  const sendBeaconMock = jest.fn();
+  // @ts-ignore
+  BeaconTracker.prototype.sendBeacon = sendBeaconMock;
+  t.sendPageView(href, referrer);
+
+  expect(sendBeaconMock).toHaveBeenCalledWith("pageView", dummpyPageMeta, {"prop1": "value1", "prop2": "value2"});
+});
+
+
+
+it("sends PageView event with all tracking providers", () => {
+  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+    tracker => {
+      const mock = jest.fn();
+      tracker.prototype.sendPageView = mock;
+      return mock;
+    }
+  );
+  const t = createDummyTracker();
+
+  const href = "https://localhost/home";
+  const referrer = "https://google.com/search?q=localhost";
+
+  t.initialize();
+  t.sendPageView(href, referrer);
+
+  mocks.forEach(mock => {
+    expect(mock).toBeCalledTimes(1);
+  });
+});
 
 it("GATracker should send pageview event", () => {
 
@@ -86,27 +121,6 @@ it("GATracker should send pageview event", () => {
 
   expect(ga).toHaveBeenCalledWith("set", "page", "/home?q=localhost&adult_exclude=true");
 
-});
-
-it("sends PageView event with all tracking providers", () => {
-  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
-    tracker => {
-      const mock = jest.fn();
-      tracker.prototype.sendPageView = mock;
-      return mock;
-    }
-  );
-  const t = createDummyTracker();
-
-  const href = "https://localhost/home";
-  const referrer = "https://google.com/search?q=localhost";
-
-  t.initialize();
-  t.sendPageView(href, referrer);
-
-  mocks.forEach(mock => {
-    expect(mock).toBeCalledTimes(1);
-  });
 });
 
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,11 +20,14 @@ export enum DeviceType {
   Paper = "paper"
 }
 
+export type ServiceProp = Record<string, string>
+
 export interface MainTrackerOptions {
   debug?: boolean;
   development?: boolean;
   userId?: string;
   deviceType: DeviceType;
+  serviceProps?: ServiceProp;
   gaOptions?: GAOptions;
   beaconOptions?: BeaconOptions;
   pixelOptions?: PixelOptions;
@@ -35,6 +38,7 @@ export interface MainTrackerOptions {
 export interface ChangeableTrackerOptions {
   userId?: string;
   deviceType?: DeviceType;
+  serviceProps?: ServiceProp;
 }
 
 export class Tracker {

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -70,10 +70,7 @@ export class BeaconTracker extends BaseTracker {
 
   public sendPageView(pageMeta: PageMeta): void {
     this.pvid = new UIDFactory(PVID).create();
-    this.sendBeacon(BeaconEventName.PageView, pageMeta, {
-      href: pageMeta.href,
-      referrer: pageMeta.referrer
-    });
+    this.sendBeacon(BeaconEventName.PageView, pageMeta, this.mainOptions.serviceProps);
     this.lastPageMeta = pageMeta;
   }
 


### PR DESCRIPTION
- 관련 아사나 태스크: [리디셀렉트 페이지뷰 이벤트에 구독 여부 정보 포함](https://app.asana.com/0/1107510315434212/1177766624344137/f) > [event-tracker 수정](https://app.asana.com/0/0/1177781676398628/f)
- 변경사항
  - `MainTrackerOptions`에 `serviceProps` 항목을 추가합니다.
- 중점적으로 리뷰받고 싶은 사항
  - 구현방식이 적절한지? `Record<string, string>` 타입을 사용하는게 적절한지?
  - 테스트 코드의 경우 `jest.fn`이 여러번 호출되면 순서에 따라 동작이 이상해지는 문제가 있습니다. 일단 테스트에 사용했던 코드는 남겨놓았고, 추후 좀 더 정교한 테스트를 위해 event-tracker 전반적인 리팩토링이 필요할 것 같습니다.
- TODO
  - 구현이 확정되면 여기에 맞추어 `README.md` 수정
  - 프론트엔드 개발 스테이징에 적용 후 beacon pageview 전송 시 구독자 정보가 `serviceProp`에 담겨서 가는지 확인
  - data-batch 코드에서 `data` 필드에 담겨서 전달되는 `serviceProp`을 풀어 셀렉트 페이지 뷰 `misc` 필드에 반영되도록 코드 변경