### PR TITLE
Add event queue

### DIFF
--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -74,7 +74,7 @@ it("BeaconTracker sends PageView event with serviceProps", () => {
   BeaconTracker.prototype.sendBeacon = sendBeaconMock;
   t.sendPageView(href, referrer);
 
-  expect(sendBeaconMock).toHaveBeenCalledWith("pageView", dummpyPageMeta, {"prop1": "value1", "prop2": "value2"});
+  expect(sendBeaconMock).toHaveBeenCalledWith("pageView", dummpyPageMeta, {"prop1": "value1", "prop2": "value2"}, undefined);
 });
 
 
@@ -95,6 +95,30 @@ it("sends PageView event with all tracking providers", () => {
   t.initialize();
   t.sendPageView(href, referrer);
 
+  mocks.forEach(mock => {
+    expect(mock).toBeCalledTimes(1);
+  });
+});
+
+it("queues events before initialize when queueWhenUninitialized is set", () => {
+  const mocks = [BeaconTracker, GATracker, PixelTracker, TagManagerTracker].map(
+    tracker => {
+      const mock = jest.fn();
+      tracker.prototype.sendPageView = mock;
+      return mock;
+    }
+  );
+  const t = createDummyTracker({ queueWhenUninitialized: true });
+
+  const href = "https://localhost/home";
+  const referrer = "https://google.com/search?q=localhost";
+
+  t.sendPageView(href, referrer);
+  mocks.forEach(mock => {
+    expect(mock).not.toBeCalled();
+  });
+
+  t.initialize();
   mocks.forEach(mock => {
     expect(mock).toBeCalledTimes(1);
   });

--- a/src/trackers/base.ts
+++ b/src/trackers/base.ts
@@ -20,11 +20,11 @@ export abstract class BaseTracker {
     this.mainOptions = newOptions;
   }
 
-  public sendPageView(pageMeta: PageMeta): void {
+  public sendPageView(pageMeta: PageMeta, ts?: Date): void {
     // Default behavior
   }
 
-  public sendEvent(name: string, data: object = {}): void {
+  public sendEvent(name: string, data: object = {}, ts?: Date): void {
     // Default behavior
   }
 }

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -42,7 +42,10 @@ export class BeaconTracker extends BaseTracker {
     return `${beaconSrc}?${queryString}`;
   }
 
-  private sendBeacon(eventName: string, pageMeta: PageMeta, data: object = {}) {
+  private sendBeacon(eventName: string, pageMeta: PageMeta, data: object = {}, ts?: Date) {
+    if (ts == null) {
+      ts = new Date();
+    }
     const search = `?${URL.qs.stringify(pageMeta.query_params)}`;
 
     const log: BeaconLog = {
@@ -54,7 +57,7 @@ export class BeaconTracker extends BaseTracker {
       ...pageMeta,
       path: `${pageMeta.path}${search}`,
       data,
-      ts: Date.now()
+      ts: ts.getTime(),
     };
 
     fetch(this.makeBeaconURL(log));
@@ -68,20 +71,20 @@ export class BeaconTracker extends BaseTracker {
     return !!this.ruid;
   }
 
-  public sendPageView(pageMeta: PageMeta): void {
+  public sendPageView(pageMeta: PageMeta, ts?: Date): void {
     this.pvid = new UIDFactory(PVID).create();
-    this.sendBeacon(BeaconEventName.PageView, pageMeta, this.mainOptions.serviceProps);
+    this.sendBeacon(BeaconEventName.PageView, pageMeta, this.mainOptions.serviceProps, ts);
     this.lastPageMeta = pageMeta;
   }
 
-  public sendEvent(name: string, data: object = {}): void {
+  public sendEvent(name: string, data: object = {}, ts?: Date): void {
     if (this.lastPageMeta === undefined) {
       throw Error(
         "[@ridi/event-tracker] Please call sendPageView method first."
       );
     }
 
-    this.sendBeacon(name, this.lastPageMeta, data);
+    this.sendBeacon(name, this.lastPageMeta, data, ts);
   }
 }
 

--- a/src/trackers/ga.ts
+++ b/src/trackers/ga.ts
@@ -43,7 +43,7 @@ export class GATracker extends BaseTracker {
     return typeof ga === "function";
   }
 
-  public sendPageView(pageMeta: PageMeta): void {
+  public sendPageView(pageMeta: PageMeta, ts?: Date): void {
     const refinedPath = this.refinePath(pageMeta.path);
     const queryString = pageMeta.href.split("?")[1] || "";
 
@@ -51,17 +51,26 @@ export class GATracker extends BaseTracker {
 
     ga("set", "page", pageName);
 
-    ga("send", "pageview", {
+    const fields: UniversalAnalytics.FieldsObject = {
+      hitType: "pageview",
       dimension1: this.mainOptions.deviceType
-    });
+    };
+    if (ts) {
+      fields.queueTime = Math.max(Date.now() - ts.getTime(), 0);
+    }
+    ga("send", fields);
   }
 
-  public sendEvent(name: string, data: { [k: string]: any }): void {
-    ga("send", {
+  public sendEvent(name: string, data: { [k: string]: any }, ts?: Date): void {
+    const fields: UniversalAnalytics.FieldsObject = {
       hitType: "event",
       eventCategory: data.category || "All",
       eventAction: data.action || name,
       eventLabel: data.label || "All"
-    });
+    };
+    if (ts) {
+      fields.queueTime = Math.max(Date.now() - ts.getTime(), 0);
+    }
+    ga("send", fields);
   }
 }


### PR DESCRIPTION
비동기 `initialize`를 위한 선행 작업입니다. `initialize` 호출 전에 전송을 요청한 이벤트를 모았다가 한 번에 전송하도록 하는 옵션을 추가했습니다.

전송 요청 당시의 타임스탬프를 저장하도록 했으나 그에 관한 대응은 현재 beacon과 ga에만 되어 있습니다.
