### PR TITLE
undefined value 를 참조하는 걸 막습니다.

### DIFF
--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -33,7 +33,7 @@ export class BeaconTracker extends BaseTracker {
         if (typeof value === "object") {
           value = JSON.stringify(value);
         } else {
-          value = value.toString();
+          value = value ? value.toString() : value ;
         }
         return [key, value].map(encodeURIComponent).join("=");
       })

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -30,10 +30,13 @@ export class BeaconTracker extends BaseTracker {
     const beaconSrc = this.options.beaconSrc;
     const queryString = Object.entries(log)
       .map(([key, value]) => {
+        if (value === undefined) {
+          return [key, "undefined"].join("=");
+        }
         if (typeof value === "object") {
           value = JSON.stringify(value);
         } else {
-          value = value ? value.toString() : value ;
+          value = value.toString();
         }
         return [key, value].map(encodeURIComponent).join("=");
       })

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -30,13 +30,10 @@ export class BeaconTracker extends BaseTracker {
     const beaconSrc = this.options.beaconSrc;
     const queryString = Object.entries(log)
       .map(([key, value]) => {
-        if (value === undefined) {
-          return [key, "undefined"].join("=");
-        }
         if (typeof value === "object") {
           value = JSON.stringify(value);
         } else {
-          value = value.toString();
+          value = String(value);
         }
         return [key, value].map(encodeURIComponent).join("=");
       })


### PR DESCRIPTION
ex) `userId` 같은 경우 MainOption interface 에 optional 로 정의 되어 있어 `undefined` 가 들어갈 수 있습니다. 
이 부분을 방어합니다.
