### PR TITLE
Fix BeaconTracker.sendPageview for prevent data missing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,4 +1,4 @@
-import {DeviceType, Tracker} from "../index";
+import {DeviceType, MainTrackerOptions, Tracker} from "../index";
 import {BeaconTracker, GATracker, KakaoTracker, PixelTracker, TagManagerTracker, TwitterTracker} from "../trackers";
 import {BaseTracker, EventTracker} from "../trackers/base";
 
@@ -30,7 +30,7 @@ afterEach(() => {
 });
 
 class TestableTracker extends Tracker {
-  constructor(additionalOptions: object = {}) {
+  constructor(additionalOptions?: Partial<MainTrackerOptions>) {
     super({
       deviceType: DeviceType.Mobile,
       serviceProps: {
@@ -88,52 +88,6 @@ class TestableTracker extends Tracker {
 }
 
 
-it("BeaconTracker sends PageView event with serviceProps", async () => {
-  const dummpyPageMeta = {
-    "device": "mobile",
-    "href": "https://localhost/home?q=localhost&adult_exclude=true",
-    "page": "home",
-    "path": "/home",
-    "query_params": {"adult_exclude": "true", "q": "localhost"},
-    "referrer": "https://google.com/search?q=localhost"
-  };
-
-  const t = new TestableTracker();
-
-  t.mocking(ALL_TRACKERS.excludes(BeaconTracker), "sendPageView");
-
-  const href = "https://localhost/home?q=localhost&adult_exclude=true";
-  const referrer = "https://google.com/search?q=localhost";
-  await t.initialize();
-
-  const sendBeaconMock = jest.fn();
-  // @ts-ignore
-  BeaconTracker.prototype.sendBeacon = sendBeaconMock;
-  t.sendPageView(href, referrer);
-
-  jest.runOnlyPendingTimers();
-  expect(sendBeaconMock).toHaveBeenCalledWith("pageView", dummpyPageMeta, {"prop1": "value1", "prop2": "value2"}, expect.any(Date));
-
-});
-
-
-it("sends PageView event with all tracking providers", async () => {
-  const t = new TestableTracker();
-  const mocks = t.mocking(ALL_TRACKERS, "sendPageView");
-
-
-  const href = "https://localhost/home";
-  const referrer = "https://google.com/search?q=localhost";
-
-  await t.initialize();
-  t.sendPageView(href, referrer);
-
-  jest.runOnlyPendingTimers();
-  mocks.forEach(mock => {
-    expect(mock).toBeCalledTimes(1);
-  });
-});
-
 it("sends events both before and after initialize", async () => {
 
   const t = new TestableTracker();
@@ -177,6 +131,81 @@ it("sends events both before and after initialize", async () => {
   });
 });
 
+it("sends PageView event with all tracking providers", async () => {
+  const t = new TestableTracker();
+  const mocks = t.mocking(ALL_TRACKERS, "sendPageView");
+
+
+  const href = "https://localhost/home";
+  const referrer = "https://google.com/search?q=localhost";
+
+  await t.initialize();
+  t.sendPageView(href, referrer);
+
+  jest.runOnlyPendingTimers();
+  mocks.forEach(mock => {
+    expect(mock).toBeCalledTimes(1);
+  });
+});
+
+it("BeaconTracker sends PageView event with serviceProps, href and referrer", async () => {
+
+  const href = "https://localhost/home?q=localhost&adult_exclude=true";
+  const referrer = "https://google.com/search?q=localhost";
+
+  const dummpyPageMeta = {
+    "device": "mobile",
+    "page": "home",
+    "path": "/home",
+    "query_params": {"adult_exclude": "true", "q": "localhost"},
+    href,
+    referrer,
+  };
+
+  const dummyBeaconUrl = "https://dummy-beacon.test";
+
+  const t = new TestableTracker(
+    {
+      beaconOptions: {
+        use: true,
+        beaconSrc: dummyBeaconUrl,
+      }
+    }
+  );
+
+
+  t.mocking(ALL_TRACKERS.excludes(BeaconTracker), "sendPageView");
+
+
+  await t.initialize();
+
+  const beaconTracker = t.getTrackerInstance(BeaconTracker);
+  await beaconTracker.initialize();
+
+  const sendBeaconMock = jest.fn();
+
+  // @ts-ignore
+  beaconTracker.sendBeacon = sendBeaconMock;
+
+  t.sendPageView(href, referrer);
+
+  jest.runOnlyPendingTimers();
+
+  delete dummpyPageMeta.referrer;
+  delete dummpyPageMeta.href;
+
+  expect(sendBeaconMock).toHaveBeenCalledWith("pageView",
+    dummpyPageMeta,
+    {
+      href,
+      referrer,
+      "prop1": "value1",
+      "prop2": "value2"
+    },
+    expect.any(Date))
+  ;
+});
+
 it("GATracker should send pageview event", async () => {
   const t = new TestableTracker();
   t.mocking(ALL_TRACKERS.excludes(GATracker), "sendPageView");
@@ -200,7 +229,7 @@ it("Test TwitterTracker", async () => {
 
   const t = new TestableTracker({
     twitterOptions: {
-      mainTid: "mainTid",
+      mainPid: "mainPid",
       booksSignUpPid: "booksSignUpPid",
       selectStartSubscriptionPid: "selectStartSubscriptionPid",
       impressionPid: "impressionPid",

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -72,8 +72,15 @@ export class BeaconTracker extends BaseTracker {
   }
 
   public sendPageView(pageMeta: PageMeta, ts?: Date): void {
+    pageMeta = Object.assign({}, pageMeta);
+
     this.pvid = new UIDFactory(PVID).create();
-    this.sendBeacon(BeaconEventName.PageView, pageMeta, this.mainOptions.serviceProps, ts);
+    const pageViewMeta = Object.assign(this.mainOptions.serviceProps,{href: pageMeta.href, referrer: pageMeta.referrer});
+
+    delete pageMeta.href;
+    delete pageMeta.referrer;
+
+    this.sendBeacon(BeaconEventName.PageView, pageMeta, pageViewMeta , ts);
     this.lastPageMeta = pageMeta;
   }
 

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -72,15 +72,19 @@ export class BeaconTracker extends BaseTracker {
   }
 
   public sendPageView(pageMeta: PageMeta, ts?: Date): void {
-    pageMeta = Object.assign({}, pageMeta);
+    pageMeta = {...pageMeta};
 
     this.pvid = new UIDFactory(PVID).create();
-    const pageViewMeta = Object.assign(this.mainOptions.serviceProps,{href: pageMeta.href, referrer: pageMeta.referrer});
+    const pageViewMeta = {
+      href: pageMeta.href,
+      referrer: pageMeta.referrer,
+      ...this.mainOptions.serviceProps,
+    };
 
     delete pageMeta.href;
     delete pageMeta.referrer;
 
-    this.sendBeacon(BeaconEventName.PageView, pageMeta, pageViewMeta , ts);
+    this.sendBeacon(BeaconEventName.PageView, pageMeta, pageViewMeta, ts);
     this.lastPageMeta = pageMeta;
   }
 


### PR DESCRIPTION
### 1. 변경 내용 요약

- 관련 아사나 태스크: [각 장르 홈 pageView 이벤트 누락](https://app.asana.com/0/search/1191667988354425/1191646615538721)
- 비콘 트래커에서 pageview 이벤트를 보낼 때 `href`와 `referrer`를 `pageMeta` 최상위가 아닌, `data` 속성 하위로 옮겼습니다. [(로그 파싱 로직 참고)](https://github.com/ridi/data-batch/blob/805c1b8ab20992155ec10d9e7be7300bceade994/scala/src/main/scala/com/ridi/data/batch/log/json/BeaconRidibooksJson.scala#L43-L61)

### 2. 중점적으로 리뷰받고 싶은 사항

- 

### 3. 배포 후

- 마스터 머지 후 릴리즈할 예정입니다.
