### PR TITLE
feat: Remove sendEvent error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ridi/event-tracker",
-  "version": "0.10.3",
+  "version": "0.10.4",
   "description": "",
   "main": "dist/cjs/index.js",
   "typings": "dist/typings/index.d.ts",

--- a/src/trackers/beacon.ts
+++ b/src/trackers/beacon.ts
@@ -95,10 +95,19 @@ export class BeaconTracker extends BaseTracker {
     data: Record<string, unknown> = {},
     ts?: Date,
   ): void {
-    if (this.lastPageMeta === undefined) {
-      throw Error(
-        '[@ridi/event-tracker] Please call sendPageView method first.',
-      );
+    if (this.lastPageMeta === undefined && window && document) {
+      const url = new URL(window.location.href, window.location, true);
+
+      const path = url.pathname;
+
+      this.lastPageMeta = {
+        page: path.split('/')[1] || 'index',
+        device: this.mainOptions.deviceType,
+        query_params: url.query,
+        path,
+        href: window.location.href,
+        referrer: document.referrer,
+      };
     }
 
     this.sendBeacon(name, this.lastPageMeta, data, ts);


### PR DESCRIPTION
- Application 측의 이벤트 호출 순서간 의존성을 없애기 위한 에러 삭제
- tracker 간 상속 및 호출 의존성에 맞게끔 meta data 설정을 하려 했으나.. beacon 메소드 내에서 window 정보를 읽어서 설정하도록 변경